### PR TITLE
refactor(agent/components): Clean up component enable/disable logic

### DIFF
--- a/autogpts/autogpt/autogpt/agents/base.py
+++ b/autogpts/autogpt/autogpt/agents/base.py
@@ -221,11 +221,6 @@ class BaseAgent(Configurable[BaseAgentSettings], metaclass=AgentABCMeta):
                 return component
         return None
 
-    def is_enabled(self, component: AgentComponent) -> bool:
-        if callable(component.enabled):
-            return component.enabled()
-        return component.enabled
-
     async def foreach_components(
         self, method_name: str, *args, retry_limit: int = 3
     ) -> Any:
@@ -243,7 +238,7 @@ class BaseAgent(Configurable[BaseAgentSettings], metaclass=AgentABCMeta):
                     method = getattr(component, method_name, None)
                     if not callable(method):
                         continue
-                    if not self.is_enabled(component):
+                    if not component.enabled:
                         self._trace.append(
                             f"   {Fore.LIGHTBLACK_EX}"
                             f"{component.__class__.__name__}{Fore.RESET}"

--- a/autogpts/autogpt/autogpt/agents/components.py
+++ b/autogpts/autogpt/autogpt/agents/components.py
@@ -4,8 +4,18 @@ from typing import Callable
 
 class AgentComponent(ABC):
     run_after: list[type["AgentComponent"]] = []
-    enabled: Callable[[], bool] | bool = True
-    disabled_reason: str = ""
+    _enabled: Callable[[], bool] | bool = True
+    _disabled_reason: str = ""
+
+    @property
+    def enabled(self) -> bool:
+        if callable(self._enabled):
+            return self._enabled()
+        return self._enabled
+
+    @property
+    def disabled_reason(self) -> str:
+        return self._disabled_reason
 
 
 class ComponentError(Exception):

--- a/autogpts/autogpt/autogpt/commands/git_operations.py
+++ b/autogpts/autogpt/autogpt/commands/git_operations.py
@@ -19,8 +19,8 @@ class GitOperationsComponent(CommandProvider):
     """Provides commands to perform Git operations."""
 
     def __init__(self, config: Config):
-        self.enabled = bool(config.github_username and config.github_api_key)
-        self.disabled_reason = "Configure github_username and github_api_key."
+        self._enabled = bool(config.github_username and config.github_api_key)
+        self._disabled_reason = "Configure github_username and github_api_key."
         self.legacy_config = config
 
     def get_commands(self) -> Iterator[Command]:

--- a/autogpts/autogpt/autogpt/commands/image_gen.py
+++ b/autogpts/autogpt/autogpt/commands/image_gen.py
@@ -31,8 +31,8 @@ class ImageGeneratorComponent(CommandProvider):
     """A component that provides commands to generate images from text prompts."""
 
     def __init__(self, workspace: FileStorage, config: Config):
-        self.enabled = bool(config.image_provider)
-        self.disabled_reason = "No image provider set."
+        self._enabled = bool(config.image_provider)
+        self._disabled_reason = "No image provider set."
         self.workspace = workspace
         self.legacy_config = config
 

--- a/autogpts/autogpt/autogpt/commands/user_interaction.py
+++ b/autogpts/autogpt/autogpt/commands/user_interaction.py
@@ -14,7 +14,7 @@ class UserInteractionComponent(CommandProvider):
 
     def __init__(self, config: Config):
         self.config = config
-        self.enabled = not config.noninteractive_mode
+        self._enabled = not config.noninteractive_mode
 
     def get_commands(self) -> Iterator[Command]:
         yield self.ask_user

--- a/docs/content/AutoGPT/component agent/components.md
+++ b/docs/content/AutoGPT/component agent/components.md
@@ -56,17 +56,24 @@ class MyAgent(Agent):
 
 ## Disabling components
 
-You can control which components are enabled by setting their `enabled` attribute. You can either provide a `bool` value or a `callable[[], bool]` that will be called each time the component is about to be executed. This way you can dynamically enable or disable components based on some conditions.
-You can also provide a reason for disabling the component by setting `disabled_reason`. The reason will be visible in the debug information.
+You can control which components are enabled by setting their `_enabled` attribute.
+Either provide a `bool` value or a `Callable[[], bool]`, will be checked each time
+the component is about to be executed. This way you can dynamically enable or disable
+components based on some conditions.
+You can also provide a reason for disabling the component by setting `_disabled_reason`.
+The reason will be visible in the debug information.
 
 ```py
 class DisabledComponent(MessageProvider):
     def __init__(self):
         # Disable this component
-        self.enabled = False
-        self.disabled_reason = "This component is disabled because of reasons."
-        # Or disable based on some condition
-        self.enabled = self.some_condition
+        self._enabled = False
+        self._disabled_reason = "This component is disabled because of reasons."
+
+        # Or disable based on some condition, either statically...:
+        self._enabled = self.some_property is not None
+        # ... or dynamically:
+        self._enabled = lambda: self.some_property is not None
 
     # This method will never be called
     def get_messages(self) -> Iterator[ChatMessage]:


### PR DESCRIPTION
- Rename `AgentComponent` attributes `enabled` -> `_enabled` and `disabled` -> `_disabled`
- Make `AgentComponent.enabled` and `AgentComponent.disabled_reason` calculated properties based on `_enabled` and `_disabled`
- Remove `BaseAgent.is_enabled(component)` method, use `component.enabled` instead
- Amend component documentation